### PR TITLE
make selected measures configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,10 @@ that will be shown when the user first opens Pivot. Default `P1D` (1 day).
 The name of the measure that will be used for default sorting. It is commonly set to the measure that represents the
 count of events. Default: the first measure.
 
+**defaultSelectedMeasures** (string[])
+
+The names of the measures that will be selected by default. Default: first four measures.
+
 **defaultPinnedDimensions** (string[])
 
 The names of the dimensions (in order) that will appear *pinned* by default on the right panel. Default: `[]`.

--- a/src/common/models/data-source/data-source.mocha.ts
+++ b/src/common/models/data-source/data-source.mocha.ts
@@ -140,6 +140,7 @@ describe('DataSource', () => {
         "defaultDuration": "P1D",
         "defaultFilter": { "op": "literal", "value": true },
         "defaultPinnedDimensions": [],
+        "defaultSelectedMeasures": [],
         "defaultSortMeasure": "added",
         "defaultTimezone": "Etc/UTC",
         "dimensions": [
@@ -257,6 +258,7 @@ describe('DataSource', () => {
         "defaultDuration": "P1D",
         "defaultFilter": { "op": "literal", "value": true },
         "defaultPinnedDimensions": [],
+        "defaultSelectedMeasures": [],
         "defaultSortMeasure": "added",
         "defaultTimezone": "Etc/UTC",
         "timeAttribute": '__time',
@@ -350,6 +352,7 @@ describe('DataSource', () => {
         "defaultDuration": "P1D",
         "defaultFilter": { "op": "literal", "value": true },
         "defaultPinnedDimensions": [],
+        "defaultSelectedMeasures": [],
         "defaultSortMeasure": "added",
         "defaultTimezone": "Etc/UTC",
         "timeAttribute": '__time',
@@ -484,6 +487,7 @@ describe('DataSource', () => {
           "value": true
         },
         "defaultPinnedDimensions": [],
+        "defaultSelectedMeasures": [],
         "defaultSortMeasure": "added_love_",
         "defaultTimezone": "Etc/UTC",
         "dimensions": [

--- a/src/common/models/data-source/data-source.mock.ts
+++ b/src/common/models/data-source/data-source.mock.ts
@@ -55,6 +55,7 @@ export class DataSourceMock {
       defaultDuration: 'P3D',
       defaultSortMeasure: 'count',
       defaultPinnedDimensions: ['articleName'],
+      defaultSelectedMeasures: ['count'],
       refreshRule: {
         time: new Date('2016-04-30T12:39:51.350Z'),
         rule: "fixed"
@@ -107,6 +108,7 @@ export class DataSourceMock {
       defaultDuration: 'P3D',
       defaultSortMeasure: 'count',
       defaultPinnedDimensions: ['tweet'],
+      defaultSelectedMeasures: ['count'],
       refreshRule: {
         refresh: "PT1M",
         rule: "fixed"

--- a/src/common/models/data-source/data-source.ts
+++ b/src/common/models/data-source/data-source.ts
@@ -71,6 +71,7 @@ export interface DataSourceValue {
   defaultFilter: Filter;
   defaultDuration: Duration;
   defaultSortMeasure: string;
+  defaultSelectedMeasures?: OrderedSet<string>;
   defaultPinnedDimensions?: OrderedSet<string>;
   refreshRule: RefreshRule;
   maxTime?: MaxTime;
@@ -98,6 +99,7 @@ export interface DataSourceJS {
   defaultFilter?: FilterJS;
   defaultDuration?: string;
   defaultSortMeasure?: string;
+  defaultSelectedMeasures?: string[];
   defaultPinnedDimensions?: string[];
   refreshRule?: RefreshRuleJS;
   maxTime?: MaxTimeJS;
@@ -296,6 +298,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
       defaultFilter: parameters.defaultFilter ? Filter.fromJS(parameters.defaultFilter) : Filter.EMPTY,
       defaultDuration: parameters.defaultDuration ? Duration.fromJS(parameters.defaultDuration) : DataSource.DEFAULT_DURATION,
       defaultSortMeasure: parameters.defaultSortMeasure || (measures.size ? measures.first().name : null),
+      defaultSelectedMeasures: OrderedSet(parameters.defaultSelectedMeasures || measures.toArray().slice(0, 4).map(m => m.name)),
       defaultPinnedDimensions: OrderedSet(parameters.defaultPinnedDimensions || []),
       refreshRule,
       maxTime
@@ -324,6 +327,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
   public defaultFilter: Filter;
   public defaultDuration: Duration;
   public defaultSortMeasure: string;
+  public defaultSelectedMeasures: OrderedSet<string>;
   public defaultPinnedDimensions: OrderedSet<string>;
   public refreshRule: RefreshRule;
   public maxTime: MaxTime;
@@ -352,6 +356,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
     this.defaultFilter = parameters.defaultFilter;
     this.defaultDuration = parameters.defaultDuration;
     this.defaultSortMeasure = parameters.defaultSortMeasure;
+    this.defaultSelectedMeasures = parameters.defaultSelectedMeasures;
     this.defaultPinnedDimensions = parameters.defaultPinnedDimensions;
     this.refreshRule = parameters.refreshRule;
     this.maxTime = parameters.maxTime;
@@ -382,6 +387,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
       defaultFilter: this.defaultFilter,
       defaultDuration: this.defaultDuration,
       defaultSortMeasure: this.defaultSortMeasure,
+      defaultSelectedMeasures: this.defaultSelectedMeasures,
       defaultPinnedDimensions: this.defaultPinnedDimensions,
       refreshRule: this.refreshRule,
       maxTime: this.maxTime
@@ -405,6 +411,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
       defaultFilter: this.defaultFilter.toJS(),
       defaultDuration: this.defaultDuration.toJS(),
       defaultSortMeasure: this.defaultSortMeasure,
+      defaultSelectedMeasures: this.defaultSelectedMeasures.toArray(),
       defaultPinnedDimensions: this.defaultPinnedDimensions.toArray(),
       refreshRule: this.refreshRule.toJS()
     };
@@ -452,6 +459,7 @@ export class DataSource implements Instance<DataSourceValue, DataSourceJS> {
       this.defaultFilter.equals(other.defaultFilter) &&
       this.defaultDuration.equals(other.defaultDuration) &&
       this.defaultSortMeasure === other.defaultSortMeasure &&
+      this.defaultSelectedMeasures.equals(other.defaultSelectedMeasures) &&
       this.defaultPinnedDimensions.equals(other.defaultPinnedDimensions) &&
       this.refreshRule.equals(other.refreshRule);
   }

--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -166,7 +166,7 @@ export class Essence implements Instance<EssenceValue, EssenceJS> {
       splits,
       multiMeasureMode: false,
       singleMeasure: dataSource.defaultSortMeasure,
-      selectedMeasures: OrderedSet(dataSource.measures.toArray().slice(0, 4).map(m => m.name)),
+      selectedMeasures: dataSource.defaultSelectedMeasures,
       pinnedDimensions: dataSource.defaultPinnedDimensions,
       colors: null,
       pinnedSort: dataSource.defaultSortMeasure,

--- a/src/common/utils/yaml-helper/yaml-helper.ts
+++ b/src/common/utils/yaml-helper/yaml-helper.ts
@@ -124,6 +124,13 @@ export function dataSourceToYAML(dataSource: DataSource, withComments: boolean):
   lines.push(`    defaultSortMeasure: ${defaultSortMeasure}`, '');
 
 
+  var defaultSelectedMeasures = dataSource.defaultSelectedMeasures.toArray();
+  if (withComments) {
+    lines.push("    # The names of measures that are selected by default");
+  }
+  lines.push(`    defaultSelectedMeasures: ${JSON.stringify(defaultSelectedMeasures)}`, '');
+
+
   var defaultPinnedDimensions = dataSource.defaultPinnedDimensions.toArray();
   if (withComments) {
     lines.push("    # The names of dimensions that are pinned by default (in order that they will appear in the pin bar)");


### PR DESCRIPTION
This is a small patch to make the measures that are selected by default configurable with a fallback to the previous behaviour if nothing is configured.