### PR TITLE
Upgraded the laborer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp": "3.9.1",
     "istanbul": "0.4.3",
     "jsdom": "9.2.1",
-    "laborer": "2.5.15",
+    "laborer": "2.5.16",
     "mkdirp": "0.5.1",
     "mocha": "2.5.3",
     "react-addons-test-utils": "15.1.0",


### PR DESCRIPTION
The 2.5.15 version appeared to have a typo in its linting rules:
  node_modules/laborer/sasslint-rules.js:  "no-color-keyword": 1,

That broke the gulp build with:
   Error: Rule `no-color-keyword` could not be found!

The rule is "no-color-keywords".  This is fixed in the latest version.