### PR TITLE
change sort if on measure

### DIFF
--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -787,6 +787,7 @@ export class Essence implements Instance<EssenceValue, EssenceJS> {
     if (measure.name === this.singleMeasure) return this;
     var value = this.valueOf();
     value.singleMeasure = measure.name;
+    value.splits = value.splits.changeSortIfOnMeasure(this.singleMeasure, measure.name);
     value.pinnedSort = measure.name;
     return new Essence(value);
   }

--- a/src/common/models/splits/splits.ts
+++ b/src/common/models/splits/splits.ts
@@ -213,6 +213,22 @@ export class Splits implements Instance<SplitsValue, SplitsJS> {
     return this.splitCombines.some((splitCombine) => splitCombine.timezoneDependant());
   }
 
+  public changeSortIfOnMeasure(fromMeasure: string, toMeasure: string): Splits {
+    var changed = false;
+    var newSplitCombines = <List<SplitCombine>>this.splitCombines.map((splitCombine) => {
+      const { sortAction } = splitCombine;
+      if (!sortAction || sortAction.refName() !== fromMeasure) return splitCombine;
+
+      changed = true;
+      return splitCombine.changeSortAction(new SortAction({
+        expression: $(toMeasure),
+        direction: sortAction.direction
+      }));
+    });
+
+    return changed ? new Splits(newSplitCombines) : this;
+  }
+
 }
 check = Splits;
 


### PR DESCRIPTION
In single measure mode, if the user selects a new measure and was previously sorted on a measure start sorting on the new measure instead.