### PR TITLE
go to presets by default when not full days

### DIFF
--- a/src/client/components/time-filter-menu/time-filter-menu.tsx
+++ b/src/client/components/time-filter-menu/time-filter-menu.tsx
@@ -84,9 +84,12 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
     var selectedTimeRange = (selectedTimeRangeSet && selectedTimeRangeSet.size() === 1) ? selectedTimeRangeSet.elements[0] : null;
     var clause = filter.clauseForExpression(dimensionExpression);
 
+    var extentRange = selectedTimeRangeSet.extent();
+    var lessThanFullDay = extentRange.end.valueOf() - extentRange.start.valueOf() < day.canonicalLength;
+
     this.setState({
       timeSelection,
-      tab: (!clause || clause.relative) ? 'relative' : 'specific',
+      tab: (!clause || clause.relative || lessThanFullDay) ? 'relative' : 'specific',
       startTime: selectedTimeRange ? day.floor(selectedTimeRange.start, timezone) : null,
       endTime: selectedTimeRange ? day.ceil(selectedTimeRange.end, timezone) : null
     });

--- a/src/client/components/time-filter-menu/time-filter-menu.tsx
+++ b/src/client/components/time-filter-menu/time-filter-menu.tsx
@@ -84,12 +84,9 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
     var selectedTimeRange = (selectedTimeRangeSet && selectedTimeRangeSet.size() === 1) ? selectedTimeRangeSet.elements[0] : null;
     var clause = filter.clauseForExpression(dimensionExpression);
 
-    var extentRange = selectedTimeRangeSet.extent();
-    var lessThanFullDay = extentRange.end.valueOf() - extentRange.start.valueOf() < day.canonicalLength;
-
     this.setState({
       timeSelection,
-      tab: (!clause || clause.relative || lessThanFullDay) ? 'relative' : 'specific',
+      tab: (!clause || clause.relative || clause.isLessThanFullDay()) ? 'relative' : 'specific',
       startTime: selectedTimeRange ? day.floor(selectedTimeRange.start, timezone) : null,
       endTime: selectedTimeRange ? day.ceil(selectedTimeRange.end, timezone) : null
     });

--- a/src/common/models/filter-clause/filter-clause.mocha.ts
+++ b/src/common/models/filter-clause/filter-clause.mocha.ts
@@ -137,4 +137,39 @@ describe('FilterClause', () => {
       });
     });
   });
+
+  describe("isLessThanFullDay", () => {
+    it("works with less than full day", () => {
+      var clause = FilterClause.fromJS({
+        expression: { op: 'ref', name: 'time' },
+        selection: {
+          op: 'literal',
+          value: {
+            "setType": "TIME_RANGE",
+            "elements": [{ start: new Date('2015-01-26T01:00:00Z'), end: new Date('2015-01-26T04:00:00Z') }]
+          },
+          "type": "SET"
+        }
+      });
+      expect(clause.isLessThanFullDay()).to.equal(true);
+    });
+
+    it("returns false for exactly one day", () => {
+      var clause = FilterClause.fromJS({
+        expression: { op: 'ref', name: 'time' },
+        selection: {
+          op: 'literal',
+          value: {
+            "setType": "TIME_RANGE",
+            "elements": [{ start: new Date('2015-01-26T01:00:00Z'), end: new Date('2015-01-27T01:00:00Z') }],
+            "bounds": "()"
+          },
+          "type": "SET"
+        }
+      });
+      expect(clause.isLessThanFullDay()).to.equal(false);
+    });
+
+  });
+
 });

--- a/src/common/models/filter-clause/filter-clause.ts
+++ b/src/common/models/filter-clause/filter-clause.ts
@@ -1,5 +1,5 @@
 import { Class, Instance, isInstanceOf } from 'immutable-class';
-import { Timezone, Duration, minute } from 'chronoshift';
+import { Timezone, Duration, minute, day } from 'chronoshift';
 import { $, r, Expression, ExpressionJS, LiteralExpression, RefExpression, Set, SetJS, ChainExpression, NotAction, OverlapAction, InAction, Range, TimeRange, Datum, NumberRange } from 'plywood';
 
 // Basically these represent
@@ -155,6 +155,12 @@ export class FilterClause implements Instance<FilterClauseValue, FilterClauseJS>
   public getExtent(): Range<any> {
     var mySet = this.getLiteralSet();
     return mySet ? mySet.extent() : null;
+  }
+
+  public isLessThanFullDay(): boolean {
+    var extent = this.getExtent();
+    if (!extent) return false;
+    return extent.end.valueOf() - extent.start.valueOf() < day.canonicalLength;
   }
 
   public changeSelection(selection: Expression) {

--- a/src/common/utils/formatter/formatter.ts
+++ b/src/common/utils/formatter/formatter.ts
@@ -72,7 +72,7 @@ export function formatterFromData(values: number[], format: string): Formatter {
 }
 
 export function formatNumberRange(value: NumberRange) {
-  return `${formatValue(value.start)}-${formatValue(value.end)}`;
+  return `${formatValue(value.start)} to ${formatValue(value.end)}`;
 }
 
 export function formatValue(value: any, timezone?: Timezone, displayYear?: DisplayYear): string {


### PR DESCRIPTION
"right now, when you open the time filter menu, if the current filter matches one of the presets, it opens the presets tab, and otherwise, it opens the calendar tab.

really, it should open the presets tab in the case where you are not looking at full days, too. probably."