### PR TITLE
filter menu to prominently show selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For updates follow [@implydata](https://twitter.com/implydata) on Twitter.
 
+## 0.9.16
+
+- Selected filtered items appear at top of menu
+
 ## 0.9.15
 
 - Allow continuous dimension in two split line chart

--- a/src/client/components/string-filter-menu/string-filter-menu.tsx
+++ b/src/client/components/string-filter-menu/string-filter-menu.tsx
@@ -6,7 +6,7 @@ import { Fn } from '../../../common/utils/general/general';
 import { STRINGS, MAX_SEARCH_LENGTH, SEARCH_WAIT } from '../../config/constants';
 import { Stage, Clicker, Essence, DataSource, Filter, FilterClause, FilterMode, Dimension, Measure, Colors, DragPosition } from '../../../common/models/index';
 import { collect } from '../../../common/utils/general/general';
-import { enterKey } from '../../utils/dom/dom';
+import { enterKey, classNames } from '../../utils/dom/dom';
 import { ClearableInput } from '../clearable-input/clearable-input';
 import { Checkbox, CheckboxType } from '../checkbox/checkbox';
 import { Loader } from '../loader/loader';
@@ -281,7 +281,7 @@ export class StringFilterMenu extends React.Component<StringFilterMenuProps, Str
           var selected = selectedValues && selectedValues.contains(segmentValue);
 
           return <div
-            className={'row' + (selected ? ' selected' : '')}
+            className={classNames('row', { 'selected': selected })}
             key={segmentValueStr}
             title={segmentValueStr}
             onClick={this.onValueClick.bind(this, segmentValue)}
@@ -299,12 +299,7 @@ export class StringFilterMenu extends React.Component<StringFilterMenuProps, Str
       message = <div className="message">{'No results for "' + searchText + '"'}</div>;
     }
 
-    var className = [
-      'menu-table',
-      (hasMore ? 'has-more' : 'no-more')
-    ].join(' ');
-
-    return <div className={className}>
+    return <div className={classNames('menu-table', hasMore ? 'has-more' : 'no-more')}>
       <div className="side-by-side">
         <FilterOptionsDropdown
           selectedOption={filterMode}

--- a/src/client/components/string-filter-menu/string-filter-menu.tsx
+++ b/src/client/components/string-filter-menu/string-filter-menu.tsx
@@ -1,7 +1,7 @@
 require('./string-filter-menu.css');
 
 import * as React from 'react';
-import { $, ply, r, Expression, Executor, Dataset, SortAction, Set } from 'plywood';
+import { $, ply, r, Expression, Executor, Dataset, SortAction, Set, Datum } from 'plywood';
 import { Fn } from '../../../common/utils/general/general';
 import { STRINGS, MAX_SEARCH_LENGTH, SEARCH_WAIT } from '../../config/constants';
 import { Stage, Clicker, Essence, DataSource, Filter, FilterClause, FilterMode, Dimension, Measure, Colors, DragPosition } from '../../../common/models/index';
@@ -90,6 +90,24 @@ export class StringFilterMenu extends React.Component<StringFilterMenuProps, Str
       .then(
         (dataset: Dataset) => {
           if (!this.mounted) return;
+          // selectedValues is set before this.mounted flag
+          const { selectedValues } = this.state;
+          if (selectedValues && selectedValues.elements.length > 0) {
+            var selectedElements = selectedValues.elements;
+            var dimensionName = dimension.name;
+            var filtered = dataset.data.filter((d) => {
+              var dimValue = d[dimensionName];
+              return selectedElements.indexOf(dimValue !== null ? String(dimValue) : null) === -1;
+            });
+
+            var selectedDummies: Datum[] = selectedElements.map((v) => {
+              var dummyDatum: Datum = {};
+              dummyDatum[dimensionName] = v;
+              return dummyDatum;
+            });
+
+            dataset.data = selectedDummies.concat(filtered);
+          }
           this.setState({
             loading: false,
             dataset,

--- a/src/client/components/string-filter-menu/string-filter-menu.tsx
+++ b/src/client/components/string-filter-menu/string-filter-menu.tsx
@@ -261,22 +261,22 @@ export class StringFilterMenu extends React.Component<StringFilterMenuProps, Str
     var hasMore = false;
     if (dataset) {
       hasMore = dataset.data.length > TOP_N;
-      var rowData = dataset.data.slice(0, TOP_N);
+      var promotedElements = promotedValues ? promotedValues.elements : [];
+      var rowData = dataset.data.slice(0, TOP_N).filter((d) => {
+        return promotedElements.indexOf(d[dimension.name]) === -1;
+      });
+      var rowStrings = promotedElements.concat(rowData.map((d) => d[dimension.name]));
 
       if (searchText) {
         var searchTextLower = searchText.toLowerCase();
-        rowData = rowData.filter((d) => {
-          return String(d[dimension.name]).toLowerCase().indexOf(searchTextLower) !== -1;
+        rowStrings = rowStrings.filter((d) => {
+          return String(d).toLowerCase().indexOf(searchTextLower) !== -1;
         });
       }
 
       var checkboxType = filterMode === Filter.EXCLUDED ? 'cross' : 'check';
-      var promotedElements = promotedValues ? promotedValues.elements : [];
 
-      rows = promotedElements.concat(rowData)
-        .filter((d) => { return promotedElements.indexOf(d[dimension.name]) === -1; })
-        .map((d) => {
-          var segmentValue = typeof d === 'string' ? d : d[dimension.name];
+      rows = rowStrings.map((segmentValue) => {
           var segmentValueStr = String(segmentValue);
           var selected = selectedValues && selectedValues.contains(segmentValue);
 


### PR DESCRIPTION
this is done in fetchData and not render so that
-reordering only happens when menu opens
-all rows in menu are loaded at the same time 