### PR TITLE
Fix documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ The timeout to set on the queries in ms. Default: 40000
 
 **sourceListScan** ('disable' | 'auto')
 
-Should the sources of this cluster be automatically scanned and new sources added as data cubes. Default: 'disable'
+Should the sources of this cluster be automatically scanned and new sources added as data cubes. Default: 'auto'
 
 **sourceListRefreshOnLoad** (boolean)
 


### PR DESCRIPTION
When I configured a 0.9.27 pivot, it kept auto-discovering sources until I set this explicitly to disable.  I'm assuming the documentation is wrong, so this is a PR to fix that.