### PR TITLE
non bucketed time

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,9 +281,9 @@ If you mainly care about smaller intervals, you might want to set it to: `['PT1S
 
 Alternatively, if you mainly care about large intervals, you might want to try: `['P1D', 'P1W', 'P1M', 'P3M', 'P1Y']`
 
-**bucketingStrategy** ('alwaysBucket' | 'neverBucket')
+**bucketingStrategy** ('defaultBucket' | 'defaultNoBucket')
 
-Specify whether or not the dimension should be bucketed. If unspecified defaults to 'alwaysBucket' for time and numeric dimensions.
+Specify whether or not the dimension should be bucketed by default. If unspecified defaults to 'defaultBucket' for time and numeric dimensions.
 
 **sortStrategy** ('self' | `someMeasureName`)
 

--- a/src/client/components/chart-line/chart-line.tsx
+++ b/src/client/components/chart-line/chart-line.tsx
@@ -20,7 +20,7 @@ import { immutableEqual } from 'immutable-class';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as d3 from 'd3';
-import { $, Expression, Executor, Dataset, Datum, TimeRange, PlywoodRange, NumberRange } from 'plywood';
+import { $, Expression, Executor, Dataset, Datum, TimeRange, PlywoodRange, NumberRange, Range } from 'plywood';
 import { Stage, Filter, Dimension, Measure } from '../../../common/models/index';
 
 const lineFn = d3.svg.line();
@@ -57,7 +57,8 @@ export class ChartLine extends React.Component<ChartLineProps, ChartLineState> {
     for (var i = 0; i < ds.length; i++) {
       var datum = ds[i];
       var range = getX(datum) as PlywoodRange;
-      if (!range) return null; // Incorrect data loaded
+
+      if (!range || !Range.isRange(range)) return null; // !range => Incorrect data loaded, !Range.isRange => temp solution for non-bucketed reaching here
 
       var rangeMidpoint = (range as NumberRange | TimeRange).midpoint();
       var measureValue = getY(datum);

--- a/src/client/components/time-filter-menu/time-filter-menu.tsx
+++ b/src/client/components/time-filter-menu/time-filter-menu.tsx
@@ -18,7 +18,7 @@ require('./time-filter-menu.css');
 
 import * as React from 'react';
 import { Timezone, WallTime, Duration, second, minute, hour, day, week, month, year } from 'chronoshift';
-import { $, r, Expression, TimeRange } from 'plywood';
+import { $, r, Expression, LiteralExpression, TimeRange, Range, Set } from 'plywood';
 import { Fn } from '../../../common/utils/general/general';
 import { STRINGS } from '../../config/constants';
 import { Clicker, Essence, Filter, FilterClause, Dimension } from '../../../common/models/index';
@@ -27,6 +27,11 @@ import { enterKey, classNames } from '../../utils/dom/dom';
 import { Button } from '../button/button';
 import { ButtonGroup } from '../button-group/button-group';
 import { DateRangePicker } from '../date-range-picker/date-range-picker';
+
+function makeDateIntoTimeRange(input: any): TimeRange {
+  var endShift = Date.parse(input).valueOf() + 1;
+  return new TimeRange({ start: input, end: new Date(endShift) });
+}
 
 export interface Preset {
   name: string;
@@ -98,6 +103,7 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
     var timeSelection = filter.getSelection(dimensionExpression);
     var selectedTimeRangeSet = essence.getEffectiveFilter().getLiteralSet(dimensionExpression);
     var selectedTimeRange = (selectedTimeRangeSet && selectedTimeRangeSet.size() === 1) ? selectedTimeRangeSet.elements[0] : null;
+    if (selectedTimeRange && !Range.isRange(selectedTimeRange)) selectedTimeRange = makeDateIntoTimeRange(selectedTimeRange);
     var clause = filter.clauseForExpression(dimensionExpression);
 
     this.setState({
@@ -212,7 +218,18 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
       >{preset.name}</button>;
     };
 
-    var previewTimeRange = essence.evaluateSelection(hoverPreset ? hoverPreset.selection : timeSelection);
+    var previewTimeRange: TimeRange = null;
+    if (timeSelection && timeSelection.type !== 'TIME_RANGE') {
+      let { value } = timeSelection as LiteralExpression;
+      if (!Set.isSet(value)) throw new Error(`Unrecognized filter value ${value}`);
+      if (value.size() !== 1) throw new Error(`Can only filter on one time`);
+
+      let time = value.elements[0];
+      previewTimeRange = makeDateIntoTimeRange(time);
+    } else {
+      previewTimeRange = essence.evaluateSelection(hoverPreset ? hoverPreset.selection : timeSelection);
+    }
+
     var previewText = previewTimeRange ? formatTimeRange(previewTimeRange, timezone, DisplayYear.IF_DIFF) : STRINGS.noFilter;
     var maxTimeBasedPresets = <div>
       <div className="type">{STRINGS.latest}</div>

--- a/src/client/components/time-filter-menu/time-filter-menu.tsx
+++ b/src/client/components/time-filter-menu/time-filter-menu.tsx
@@ -28,9 +28,8 @@ import { Button } from '../button/button';
 import { ButtonGroup } from '../button-group/button-group';
 import { DateRangePicker } from '../date-range-picker/date-range-picker';
 
-function makeDateIntoTimeRange(input: any): TimeRange {
-  var endShift = Date.parse(input).valueOf() + 1;
-  return new TimeRange({ start: input, end: new Date(endShift) });
+function makeDateIntoTimeRange(input: Date, timezone: Timezone): TimeRange {
+  return new TimeRange({ start: second.shift(input, timezone, - 1), end: second.shift(input, timezone, 1) });
 }
 
 export interface Preset {
@@ -103,7 +102,7 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
     var timeSelection = filter.getSelection(dimensionExpression);
     var selectedTimeRangeSet = essence.getEffectiveFilter().getLiteralSet(dimensionExpression);
     var selectedTimeRange = (selectedTimeRangeSet && selectedTimeRangeSet.size() === 1) ? selectedTimeRangeSet.elements[0] : null;
-    if (selectedTimeRange && !Range.isRange(selectedTimeRange)) selectedTimeRange = makeDateIntoTimeRange(selectedTimeRange);
+    if (selectedTimeRange && !Range.isRange(selectedTimeRange)) selectedTimeRange = makeDateIntoTimeRange(selectedTimeRange, timezone);
     var clause = filter.clauseForExpression(dimensionExpression);
 
     this.setState({
@@ -225,7 +224,7 @@ export class TimeFilterMenu extends React.Component<TimeFilterMenuProps, TimeFil
       if (value.size() !== 1) throw new Error(`Can only filter on one time`);
 
       let time = value.elements[0];
-      previewTimeRange = makeDateIntoTimeRange(time);
+      previewTimeRange = makeDateIntoTimeRange(time, timezone);
     } else {
       previewTimeRange = essence.evaluateSelection(hoverPreset ? hoverPreset.selection : timeSelection);
     }

--- a/src/client/views/settings-view/dimension-modal/dimension-modal.tsx
+++ b/src/client/views/settings-view/dimension-modal/dimension-modal.tsx
@@ -56,8 +56,8 @@ export class DimensionModal extends React.Component<DimensionModalProps, Dimensi
   ];
 
   static BUCKETING_STRATEGIES = [
-    {label: 'Default bucket', value: Dimension.defaultBucket},
-    {label: 'Default don\'t bucket', value: Dimension.defaultNoBucket}
+    {label: 'Bucket', value: Dimension.defaultBucket},
+    {label: 'Don’t Bucket', value: Dimension.defaultNoBucket}
   ];
 
   constructor() {

--- a/src/client/views/settings-view/dimension-modal/dimension-modal.tsx
+++ b/src/client/views/settings-view/dimension-modal/dimension-modal.tsx
@@ -55,6 +55,11 @@ export class DimensionModal extends React.Component<DimensionModalProps, Dimensi
     {label: 'String-geo', value: 'string-geo'}
   ];
 
+  static BUCKETING_STRATEGIES = [
+    {label: 'Default bucket', value: Dimension.defaultBucket},
+    {label: 'Default don\'t bucket', value: Dimension.defaultNoBucket}
+  ];
+
   constructor() {
     super();
     this.state = {
@@ -125,6 +130,7 @@ export class DimensionModal extends React.Component<DimensionModalProps, Dimensi
     if (!newDimension) return null;
 
     const isTime = newDimension.kind === 'time';
+    const isContinuous = newDimension.isContinuous();
 
     var makeLabel = FormLabel.simpleGenerator(LABELS, errors, true);
     var makeTextInput = ImmutableInput.simpleGenerator(newDimension, this.onChange.bind(this));
@@ -161,6 +167,9 @@ export class DimensionModal extends React.Component<DimensionModalProps, Dimensi
           valueToString={(value: any) => value ? value.map(granularityToString).join(', ') : undefined}
           stringToValue={(str: string) => str.split(/\s*,\s*/).map(granularityFromJS)}
         /> : null}
+
+        {isContinuous ? makeLabel('bucketingStrategy') : null}
+        {isContinuous ? makeDropDownInput('bucketingStrategy', DimensionModal.BUCKETING_STRATEGIES) : null}
 
       </form>
 

--- a/src/client/visualizations/line-chart/line-chart.tsx
+++ b/src/client/visualizations/line-chart/line-chart.tsx
@@ -57,7 +57,7 @@ function findClosest(data: Datum[], dragDate: Date, scaleX: (v: continuousValueT
   var minDist = Infinity;
   for (var datum of data) {
     var continuousSegmentValue = datum[continuousDimension.name] as (TimeRange | NumberRange);
-    if (!continuousSegmentValue) continue;
+    if (!continuousSegmentValue || !Range.isRange(continuousSegmentValue)) continue; // !Range.isRange => temp solution for non-bucketed reaching here
     var mid = continuousSegmentValue.midpoint();
     var dist = Math.abs(mid.valueOf() - dragDate.valueOf());
     var distPx = Math.abs(scaleX(mid) - scaleX(dragDate));

--- a/src/client/visualizations/line-chart/line-chart.tsx
+++ b/src/client/visualizations/line-chart/line-chart.tsx
@@ -178,6 +178,7 @@ export class LineChart extends BaseVisualization<LineChartState> {
     const { essence } = this.props;
     const { splits, timezone } = essence;
     var continuousSplit = splits.last();
+    if (!continuousSplit.bucketAction) return dragRange; // temp solution for non-bucketed reaching here
 
     if (TimeRange.isTimeRange(dragRange)) {
       var timeBucketAction = continuousSplit.bucketAction as TimeBucketAction;

--- a/src/common/models/dimension/dimension.ts
+++ b/src/common/models/dimension/dimension.ts
@@ -31,7 +31,6 @@ function typeToKind(type: string): string {
   return type.toLowerCase().replace(/_/g, '-').replace(/-range$/, '');
 }
 
-const DEFAULT_NO_BUCKET = 'defaultNoBucket';
 export type BucketingStrategy = 'defaultBucket' | 'defaultNoBucket';
 
 export interface DimensionValue {
@@ -60,6 +59,9 @@ export interface DimensionJS {
 
 var check: Class<DimensionValue, DimensionJS>;
 export class Dimension implements Instance<DimensionValue, DimensionJS> {
+  static defaultBucket: BucketingStrategy = 'defaultBucket';
+  static defaultNoBucket: BucketingStrategy = 'defaultNoBucket';
+
   static isDimension(candidate: any): candidate is Dimension {
     return isInstanceOf(candidate, Dimension);
   }
@@ -95,8 +97,8 @@ export class Dimension implements Instance<DimensionValue, DimensionJS> {
 
     var bucketingStrategy = parameters.bucketingStrategy;
     if (bucketingStrategy) {
-      if (bucketingStrategy === 'neverBucket') bucketingStrategy = 'defaultNoBucket';
-      if (bucketingStrategy === 'alwaysBucket') bucketingStrategy = 'defaultBucket';
+      if (bucketingStrategy === 'neverBucket') bucketingStrategy = Dimension.defaultNoBucket;
+      if (bucketingStrategy === 'alwaysBucket') bucketingStrategy = Dimension.defaultBucket;
       value.bucketingStrategy = bucketingStrategy;
     }
 
@@ -213,7 +215,7 @@ export class Dimension implements Instance<DimensionValue, DimensionJS> {
   }
 
   public canBucketByDefault(): boolean {
-    return this.isContinuous() && this.bucketingStrategy !== DEFAULT_NO_BUCKET;
+    return this.isContinuous() && this.bucketingStrategy !== Dimension.defaultNoBucket;
   }
 
   public isContinuous() {

--- a/src/common/models/labels.ts
+++ b/src/common/models/labels.ts
@@ -50,7 +50,7 @@ export const DIMENSION = {
     description: `A set of exactly 5 granularities that you want to be available for bucketing.`
   },
   bucketingStrategy: {
-    label: `Bucketing Strategy`,
+    label: `Default Bucketing`,
     description: `Specify whether or not the dimension should be bucketed by default.`
   }
 };

--- a/src/common/models/labels.ts
+++ b/src/common/models/labels.ts
@@ -48,6 +48,10 @@ export const DIMENSION = {
   granularities: {
     label: `Granularities`,
     description: `A set of exactly 5 granularities that you want to be available for bucketing.`
+  },
+  bucketingStrategy: {
+    label: `Bucketing Strategy`,
+    description: `Specify whether or not the dimension should be bucketed by default.`
   }
 };
 

--- a/src/common/utils/formatter/formatter.ts
+++ b/src/common/utils/formatter/formatter.ts
@@ -108,19 +108,25 @@ export function formatFilterClause(dimension: Dimension, clause: FilterClause, t
 
 export function getFormattedClause(dimension: Dimension, clause: FilterClause, timezone: Timezone, verbose?: boolean): {title: string, values: string} {
   var dimKind = dimension.kind;
-  var title = (verbose || dimKind !== 'time') ? `${dimension.title}:` : '';
   var values: string;
+  var clauseSet = clause.getLiteralSet();
+
+  function getClauseLabel() {
+    var dimTitle = dimension.title;
+    if (dimKind === 'time' && !verbose) return '';
+    if (clauseSet && clauseSet.elements.length > 1 && !verbose) return `${dimTitle}`;
+    return `${dimTitle}:`;
+  }
 
   switch (dimKind) {
     case 'boolean':
     case 'number':
     case 'string':
       if (verbose) {
-        values = clause.getLiteralSet().toString();
+        values = clauseSet.toString();
       } else {
-        var setElements = clause.getLiteralSet().elements;
+        var setElements = clauseSet.elements;
         if (setElements.length > 1) {
-          title = title.replace(/:/g, ''); // no colon if value is just how many values there are
           values = `(${setElements.length})`;
         } else {
           values = formatValue(setElements[0]);
@@ -135,7 +141,7 @@ export function getFormattedClause(dimension: Dimension, clause: FilterClause, t
         var timeRange = selection.value as TimeRange;
         values = formatTimeRange(timeRange, timezone, DisplayYear.IF_DIFF);
       } else if (selectionType === "SET/TIME") {
-        values = clause.getLiteralSet().toString();
+        values = clauseSet.toString();
       }
       break;
 
@@ -143,6 +149,6 @@ export function getFormattedClause(dimension: Dimension, clause: FilterClause, t
       throw new Error(`unknown kind ${dimKind}`);
   }
 
-  return {title, values};
+  return {title: getClauseLabel(), values};
 }
 


### PR DESCRIPTION
-added bucketing strategy to settings
-handles unbucketed time in filter pills 
-until vis picking is tidied up, line chart will be picked by default for time and pickable for all continuous so try not to throw errors (instead just blank chart) for now
