### PR TITLE
Replace nodejitsu.com registry with npmjs.org in npm-shrinkwrap.json. Fixes #339.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -962,7 +962,7 @@
     "thenify-all": {
       "version": "1.6.0",
       "from": "thenify-all@>=1.6.0 <2.0.0",
-      "resolved": "http://registry.nodejitsu.com/thenify-all/-/thenify-all-1.6.0.tgz"
+      "resolved": "http://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
     },
     "through": {
       "version": "2.3.8",


### PR DESCRIPTION
registry.nodejitsu.com is currently offline and as a result package
installation via `npm install` fails.

Also, it's odd that every dependency except for `thenify-all` uses the default
registry. There's no reason for `thenify-all` to be different, and it's causing
problems.

Fixes issue #339.